### PR TITLE
[FEATURE] 리뷰 없는 캠페인 조회 리소스 변경 0.6.3

### DIFF
--- a/src/main/java/metaint/replanet/rest/reviews/entity/Review.java
+++ b/src/main/java/metaint/replanet/rest/reviews/entity/Review.java
@@ -27,7 +27,7 @@ public class Review {
     @Column(name = "description")
     private String description;
 
-    @OneToOne(optional = true, fetch = FetchType.LAZY)
+    @OneToOne(optional = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "campaign_code", referencedColumnName = "campaign_code")
     private Campaign campaign;
 

--- a/src/main/java/metaint/replanet/rest/reviews/model/controller/ReviewController.java
+++ b/src/main/java/metaint/replanet/rest/reviews/model/controller/ReviewController.java
@@ -3,6 +3,7 @@ package metaint.replanet.rest.reviews.model.controller;
 import lombok.extern.slf4j.Slf4j;
 import metaint.replanet.rest.auth.jwt.TokenProvider;
 import metaint.replanet.rest.reviews.dto.*;
+import metaint.replanet.rest.reviews.entity.Campaign;
 import metaint.replanet.rest.reviews.entity.ReviewComment;
 import metaint.replanet.rest.reviews.model.service.ReviewService;
 import okhttp3.Response;
@@ -202,4 +203,13 @@ public class ReviewController {
         return ResponseEntity.ok(email);
     }
 
+    @GetMapping("/nonExisting")
+    public ResponseEntity<List<Campaign>> getNonExistingReviewCampaigns() {
+        List<Campaign> unassociatedCampaigns = reviewService.findUnassociatedCampaigns();
+
+        return ResponseEntity.ok(unassociatedCampaigns);
+    }
+
+
 }
+

--- a/src/main/java/metaint/replanet/rest/reviews/model/service/ReviewService.java
+++ b/src/main/java/metaint/replanet/rest/reviews/model/service/ReviewService.java
@@ -101,9 +101,12 @@ public class ReviewService {
         reviewRepository.flush();
 
         ///////////////////////////////////////////////////////////////////////////////////
-        Long reviewCode = reviewRepository.findByCampaignCode(reviewDTO.getCampaignCode());
+        log.info("what is the campaignCode : " + reviewDTO.getCampaignCode());
+        Long campaignCode = reviewDTO.getCampaignCode();
+        Long reviewCode = reviewRepository.findReviewCodeByCampaignCode(campaignCode);
+        log.info("what is the fucking result??" + reviewCode);
 
-        //System.out.println("what is the fucking reviewCode??" + reviewCode);
+        log.info("what is the fucking reviewCode??" + reviewCode);
         ReviewFileDTO reviewFileDTO = new ReviewFileDTO();
 
         String imageName = UUID.randomUUID().toString().replace("-", "");
@@ -207,7 +210,7 @@ public class ReviewService {
 
                 if (imageFile != null) {
 
-                    Path filePath = Paths.get("/REPLANET_ReactAPI/public/reviewImgs").toAbsolutePath();
+                    Path filePath = Paths.get("/REPLANET_React/public/reviewImgs").toAbsolutePath();
                     Path rootPath;
                     String IMAGE_DIR = null;
 
@@ -367,5 +370,10 @@ public class ReviewService {
         log.info("[Review Service] getMemberEmail memberCode : " + memberCode);
         return reviewMemberRepository.findEmailByMemberCode(memberCode);
         //return modelMapper.map(memberEmail, MemberDTO.class);
+    }
+
+    public List<Campaign> findUnassociatedCampaigns() {
+
+        return campaignReviewRepository.findUnassociatedCampaigns();
     }
 }

--- a/src/main/java/metaint/replanet/rest/reviews/repository/CampaignReviewRepository.java
+++ b/src/main/java/metaint/replanet/rest/reviews/repository/CampaignReviewRepository.java
@@ -14,4 +14,14 @@ public interface CampaignReviewRepository extends JpaRepository<Campaign, Long> 
 
     @Query("SELECT c FROM reviewPkg_entityCampaign c ORDER BY c.campaignCode DESC")
     List<Campaign> findAllOrderedByCampaignCodeDesc();
+
+    @Query(value = "SELECT c.* " +
+            "FROM tbl_campaign_description c " +
+            "WHERE c.campaign_code NOT IN ( " +
+            "    SELECT r.campaign_code " +
+            "    FROM tbl_review r " +
+            "    WHERE r.campaign_code IS NOT NULL " +
+            ") " +
+            "AND c.end_date < CURRENT_TIMESTAMP", nativeQuery = true)
+    List<Campaign> findUnassociatedCampaigns();
 }

--- a/src/main/java/metaint/replanet/rest/reviews/repository/ReviewRepository.java
+++ b/src/main/java/metaint/replanet/rest/reviews/repository/ReviewRepository.java
@@ -15,9 +15,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             "where review_title like %:searchFilter%", nativeQuery = true)
     List<Review> findFilteredReviews(@Param("searchFilter") String searchFilter);
 
-    @Query(value = "select review_code from tbl_review " +
-            "where campaign_code = :campaignCode", nativeQuery = true)
-    Long findByCampaignCode(@Param("campaignCode") Long campaignCode);
+    @Query("SELECT r.reviewCode FROM reviewPkg_entityReview r WHERE r.campaign.campaignCode = :campaignCode")
+    Long findReviewCodeByCampaignCode(@Param("campaignCode") Long campaignCode);
+
 
     @Query(value = "select * from tbl_campaign_rev_file where review_code = :reviewCode", nativeQuery = true)
     List<Object> findByReviewCode(@Param("reviewCode")Long reviewCode);


### PR DESCRIPTION
## PR 유형 분류

- [ ]  버그픽스
- [x]  기능 추가 또는 수정
- [ ]  코드 작성 방식 또는 변수명 수정
- [ ]  리팩토링(기능, API 변경 없음)
- [ ]  빌드 관련 수정
- [ ]  설정파일 관련 수정
- [ ]  docs 관련 수정
- [ ]  기타 유형

## 이번 PR의 주요 변경 사항(직접 서술 또는 링크 첨부)

Issue Number: N/A

## 변경사항 관련 서술
기존에는 리소스 리뷰로 하여금 캠페인 정보까지 모두 가져왔으나
리뷰 없는 캠페인(후기 미등록) 조회 시, 리소스를 캠페인으로 맞춰 쿼리 NOT IN과 sub query 활용하여 request 날리는 방식


## 본 PR에 대규모 변경이 포함되어 있는지 여부(있을 경우 관련 서술)

- [ ]  Yes
- [x]  No

## 기타
